### PR TITLE
add email validation - regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 build/
 *.iml
+out/

--- a/src/main/groovy/nebula/plugin/contacts/ContactsExtension.groovy
+++ b/src/main/groovy/nebula/plugin/contacts/ContactsExtension.groovy
@@ -1,9 +1,5 @@
 package nebula.plugin.contacts
 
-import org.gradle.api.NamedDomainObjectCollection
-import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.NamedDomainObjectList
-import org.gradle.api.internal.DefaultNamedDomainObjectCollection
 import org.gradle.util.ConfigureUtil
 
 /**
@@ -11,6 +7,9 @@ import org.gradle.util.ConfigureUtil
  * TODO repeat a name and guarantee uniqueness
  */
 class ContactsExtension {
+
+    private final String emailPattern = /[_A-Za-z0-9-]+(.[_A-Za-z0-9-]+)*@[A-Za-z0-9]+(.[A-Za-z0-9]+)*(.[A-Za-z]{2,})/
+
     final LinkedHashMap<String, Contact> people
 
     ContactsExtension(LinkedHashMap<String, Contact> people) {
@@ -50,18 +49,24 @@ class ContactsExtension {
     }
 
     def addPerson(String email) {
-        // TODO Validate email address
+        validateEmail(email)
         def person = people.containsKey(email) ? people.get(email) : new Contact(email)
         people.put(email, person) // Redundant if already there, just trying to follow model below
         return person
     }
 
     def addPerson(String email, Closure closure) {
-        // TODO Validate email address
+        validateEmail(email)
         def person = people.containsKey(email) ? people.get(email).clone() : new Contact(email)
         ConfigureUtil.configure(closure, person)
         people.put(email, person)
         return person
+    }
+
+    private validateEmail(String email) {
+        if(!(email ==~  emailPattern)) {
+            throw new ContactsPluginException("$email is not a valid email")
+        }
     }
 
 }

--- a/src/main/groovy/nebula/plugin/contacts/ContactsPluginException.groovy
+++ b/src/main/groovy/nebula/plugin/contacts/ContactsPluginException.groovy
@@ -1,0 +1,7 @@
+package nebula.plugin.contacts
+
+class ContactsPluginException extends Exception {
+    ContactsPluginException(String message) {
+        super(message)
+    }
+}

--- a/src/test/groovy/nebula/plugin/contacts/ContactsExtensionSpec.groovy
+++ b/src/test/groovy/nebula/plugin/contacts/ContactsExtensionSpec.groovy
@@ -77,4 +77,19 @@ class ContactsExtensionSpec extends Specification {
         mickey.github == 'mmouse'
         mickey.twitter == 'mmouse1928'
     }
+
+    def 'fails with invalid email'() {
+        LinkedHashMap<String, Contact> people = Mock()
+        ContactsExtension extension = new ContactsExtension(people)
+        def closure = {}
+
+        when:
+        extension.'not-an-email' closure
+
+        then:
+        0 * people.put('not-an-email', _ as Contact)
+
+        ContactsPluginException e = thrown(ContactsPluginException)
+        e.message == 'not-an-email is not a valid email'
+    }
 }


### PR DESCRIPTION
Added email validation using regex.

While this could be accomplished with apache commons, two things:

* means adding a dependency
* it uses valid TLD domains that could potentially change and will make the plugin obsolete there