### PR TITLE
Merge contact values in a multi project

### DIFF
--- a/src/main/groovy/nebula/plugin/contacts/BaseContactsPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/contacts/BaseContactsPlugin.groovy
@@ -49,9 +49,8 @@ class BaseContactsPlugin implements Plugin<Project> {
         while (thisProject != null) {
             ContactsExtension contactsPath = thisProject.extensions.findByType(ContactsExtension)
             if (contactsPath) {
-                // TODO Merge values as we see them. E.g. bob exists on the root project, but has a a developer role in a subproject
                 // Ergo he exists as a developer
-                contacts += contactsPath.people.values()
+                contacts = addToContacts(contacts, contactsPath.people)
             }
             thisProject = thisProject.parent // Root Project will have a null parent
         }
@@ -81,5 +80,20 @@ class BaseContactsPlugin implements Plugin<Project> {
     List<Contact> getAllContacts() {
         // Objects are already cloned before we see it.
         return resolveContacts()
+    }
+
+    private List<Contact> addToContacts(List<Contact> contacts, Map<String, Contact> people) {
+        people.each { email, contact ->
+            Contact existingContact = contacts.find { it.email == email }
+            if(existingContact) {
+                existingContact.moniker(contact.moniker)
+                existingContact.twitter(contact.twitter)
+                existingContact.github(contact.github)
+                existingContact.roles(contact.getRoles() as String[])
+            } else {
+                contacts += contact
+            }
+        }
+        return contacts
     }
 }

--- a/src/main/groovy/nebula/plugin/contacts/Contact.groovy
+++ b/src/main/groovy/nebula/plugin/contacts/Contact.groovy
@@ -50,14 +50,20 @@ class Contact implements Named {
 
     // Temporary until we can find a annotation to do this for us
     void moniker(String moniker) {
+        if(!moniker)
+            return
         this.moniker = moniker
     }
 
     void github(String github) {
+        if(!github)
+            return
         this.github = github
     }
 
     void twitter(String twitter) {
+        if(!twitter)
+            return
         this.twitter = twitter
     }
 }

--- a/src/test/groovy/nebula/plugin/contacts/BaseContactsPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/contacts/BaseContactsPluginSpec.groovy
@@ -87,4 +87,36 @@ class BaseContactsPluginSpec extends PluginProjectSpec {
         (apply.getContacts('') as Set).size() == 1
     }
 
+    def 'collects all levels of multiproject - merges existing contacts'() {
+        def sub = ProjectBuilder.builder().withName('sub').withProjectDir(new File(projectDir, 'sub')).withParent(project).build()
+        project.subprojects.add(sub)
+
+        when:
+        project.plugins.apply(BaseContactsPlugin)
+        project.contacts {
+            'mickey@disney.com' {
+            }
+            'goofy@disney.com' {
+                role 'guest'
+            }
+        }
+        def apply = sub.plugins.apply(BaseContactsPlugin)
+        sub.contacts {
+            'mickey@disney.com' {
+                role 'guest'
+                github 'mickey'
+            }
+            'goofy@disney.com' {
+                role 'guest'
+            }
+        }
+
+        and:
+        List<Contact> contacts = apply.getAllContacts()
+
+        then:
+        contacts.size() == 2
+        (apply.getContacts('guest') as Set).size() == 2
+        contacts.find { it.github == "mickey"}
+    }
 }

--- a/src/test/groovy/nebula/plugin/contacts/BaseContactsPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/contacts/BaseContactsPluginSpec.groovy
@@ -97,7 +97,7 @@ class BaseContactsPluginSpec extends PluginProjectSpec {
             'mickey@disney.com' {
             }
             'goofy@disney.com' {
-                role 'guest'
+                github 'goofy'
             }
         }
         def apply = sub.plugins.apply(BaseContactsPlugin)
@@ -105,9 +105,11 @@ class BaseContactsPluginSpec extends PluginProjectSpec {
             'mickey@disney.com' {
                 role 'guest'
                 github 'mickey'
+                twitter 'mickey'
             }
             'goofy@disney.com' {
                 role 'guest'
+                twitter 'goofy'
             }
         }
 
@@ -117,6 +119,7 @@ class BaseContactsPluginSpec extends PluginProjectSpec {
         then:
         contacts.size() == 2
         (apply.getContacts('guest') as Set).size() == 2
-        contacts.find { it.github == "mickey"}
+        contacts.find { it.github == 'mickey' && it.twitter == 'mickey' && it.email == 'mickey@disney.com' }
+        contacts.find { it.github == 'goofy' && it.twitter == 'goofy' && it.email == 'goofy@disney.com' }
     }
 }


### PR DESCRIPTION
From the TODO: 

> // TODO Merge values as we see them. E.g. bob exists on the root project, but has a a developer role in a subproject


This assumes that the config in a sub project takes precedence (since the iteration happens from children to parents). This might need extra work if the root project should have precedence and only want to add values from sub projects when not available in the root.

For now, Looks for existing contact in `contacts`. If existing, it will replace the values for twitter, github and moniker. The roles will be added since it is a set and we add more items to it.

Please refer to the test for more details -> https://github.com/nebula-plugins/gradle-contacts-plugin/compare/master...rpalcolea:contact-merge-values?expand=1#diff-a47e4dfcd28cb65383369e9ff61fac22R90